### PR TITLE
✨ 사용자 정보에 따른 라우트 페이지 분리 (비회원/판매자/구매자) / 테스트용 판매자, 구매자 페이지 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "lucide-react": "^0.314.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.21.3",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -1997,6 +1998,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
+      "integrity": "sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4587,6 +4596,36 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.3.tgz",
+      "integrity": "sha512-a0H638ZXULv1OdkmiK6s6itNhoy33ywxmUFT/xtSoVyf9VnC7n7+VT4LjVzdIHSaF5TIh9ylUgxMXksHTgGrKg==",
+      "dependencies": {
+        "@remix-run/router": "1.14.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.3.tgz",
+      "integrity": "sha512-kNzubk7n4YHSrErzjLK72j0B5i969GsuCGazRl3G6j1zqZBLjuSlYBdVdkDOgzGdPIffUOc9nmgiadTEVoq91g==",
+      "dependencies": {
+        "@remix-run/router": "1.14.2",
+        "react-router": "6.21.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.314.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.3",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/page/ConsumerProfile.tsx
+++ b/src/page/ConsumerProfile.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ConsumerProfile() {
+  return <div>구매자 전용입니다.</div>;
+}

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -1,5 +1,45 @@
-import React from "react";
+import { Link } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/firebase";
+import SellerProfile from "./SellerProfile";
+import ConsumerProfile from "./ConsumerProfile";
 
 export default function Home() {
-  return <div>Home</div>;
+  const userInfo = localStorage.getItem("userID");
+  const [sellerFlag, setSellerFlag] = useState<boolean>(false);
+
+  const fetchUserData = async () => {
+    if (userInfo) {
+      const docRef = doc(db, "user", userInfo);
+      const docSnap = await getDoc(docRef);
+
+      if (docSnap.exists()) {
+        console.log(docSnap.data());
+        console.log(docSnap.get("isSeller"));
+        if (docSnap.get("isSeller") === true) {
+          setSellerFlag(true);
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
+    fetchUserData();
+  }, [userInfo]);
+
+  return (
+    <>
+      <h2>Home</h2>
+      {userInfo ? (
+        sellerFlag ? (
+          <SellerProfile />
+        ) : (
+          <ConsumerProfile />
+        )
+      ) : (
+        <Link to="/login">로그인 하기</Link>
+      )}
+    </>
+  );
 }

--- a/src/page/Login.tsx
+++ b/src/page/Login.tsx
@@ -1,12 +1,14 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { auth } from "@/firebase";
 import { signInWithEmailAndPassword } from "firebase/auth";
-import React, { useState } from "react";
 
 export default function Login() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
 
-  const onChange = (event) => {
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const {
       target: { name, value },
     } = event;
@@ -18,12 +20,14 @@ export default function Login() {
     }
   };
 
-  const login = async (event) => {
+  const login: React.MouseEventHandler<HTMLButtonElement> = async (event) => {
     event.preventDefault();
 
     try {
       const userInfo = await signInWithEmailAndPassword(auth, email, password);
-      console.log(userInfo.user.email);
+
+      localStorage.setItem("userID", userInfo.user.uid);
+      navigate("/");
     } catch (error) {
       console.error(error);
     }

--- a/src/page/SellerProfile.tsx
+++ b/src/page/SellerProfile.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function SellerProfile() {
+  return <div>판매자 전용입니다.</div>;
+}


### PR DESCRIPTION
# ⚡ PR 요약
사용자 정보에 따른 라우팅 페이지 분리

# 🔍 주요 변경 사항
1. 로그인 유저의 ID local storage에 저장
2. 로그인 유무에 따른 라우트 페이지 분리
3. 로그인 후 판매자, 구매자 따른 라우트 페이지 분리

# 💡 관련 이슈
Resolve #10 
