### PR TITLE
🐛 장바구니 페이지 수량 조절 버그 해결

### DIFF
--- a/src/components/card/CartCard.tsx
+++ b/src/components/card/CartCard.tsx
@@ -62,10 +62,16 @@ export default function CartCard({ item }: { item: CartType }) {
           <div>KRW {item.productPrice * item.productQuantity}</div>
           <div className="flex justify-center items-center gap-2">
             <div>Quantity : {item.productQuantity}</div>
-            <button onClick={() => setQuantity(quantity + 1)}>
+            <button
+              onClick={() =>
+                product &&
+                product.productQuantity > quantity &&
+                setQuantity(quantity + 1)
+              }
+            >
               <ChevronUpCircle size={20} />
             </button>
-            <button onClick={() => quantity > 0 && setQuantity(quantity - 1)}>
+            <button onClick={() => quantity > 1 && setQuantity(quantity - 1)}>
               <ChevronDownCircle size={20} />
             </button>
           </div>


### PR DESCRIPTION
# ⚡ PR 요약
 장바구니 페이지 수량 조절 버그 해결

# 🔍 주요 변경 사항
1.  장바구니 페이지 수량 조절 버그 해결

# 💡 관련 이슈
Resolve #57 
